### PR TITLE
Sort list of .po files

### DIFF
--- a/l10n/compile_mo.py
+++ b/l10n/compile_mo.py
@@ -19,7 +19,7 @@ def build_mo_files():
         shutil.rmtree(locale_dir)
     os.mkdir(locale_dir)
 
-    available_langs = os.listdir(po_dir)
+    available_langs = sorted(os.listdir(po_dir))
     available_langs = filter(lambda file: file.endswith('.po'), available_langs)
     available_langs = map(lambda file: file[:-3], available_langs)
 


### PR DESCRIPTION
so that package builds always give the same result
See https://reproducible-builds.org/ for why this is good.

Without this patch,
/usr/share/locale/ru_RU/LC_MESSAGES/nested.mo
(and possibly others) would sometimes differ as seen in
http://rb.zq1.de/compare.factory-20171017/nested-compare.out