### PR TITLE
Do not claim copyright for future years

### DIFF
--- a/nested/examples/Manpage/Manpage.t2t
+++ b/nested/examples/Manpage/Manpage.t2t
@@ -246,5 +246,5 @@ http://sourceforge.net/p/nestededitor/tickets/
 
 = COPYRIGHT =[copyright]
 
-Copyright (C) %%date(%Y) Carlos Jenkins, GNU GPL v2
+Copyright (C) 2013 Carlos Jenkins, GNU GPL v2
 


### PR DESCRIPTION
e.g. when building this in 2018, it would claim copyright for 2018
without any author having done anything

This also helps to make this package build reproducibly.